### PR TITLE
remove OccurenceOrderPlugin

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,7 +17,7 @@
     "cross-env": "^1.0.6",
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.4",
-    "vue-loader": "^9.0.0",
+    "vue-loader": "^9.2.2",
     "webpack": "^2.1.0-beta.20",
     "webpack-dev-server": "^2.1.0-beta.0"
   }

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -51,7 +51,6 @@ if (process.env.NODE_ENV === 'production') {
       compress: {
         warnings: false
       }
-    }),
-    new webpack.optimize.OccurenceOrderPlugin()
+    })
   ])
 }


### PR DESCRIPTION
In webpack 2.0, the plugin is no longer needed and occurrence order is on by default.
https://gist.github.com/sokra/27b24881210b56bbaff7#occurrence-order
