### PR TITLE
update vue-loader version.

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -17,7 +17,7 @@
     "cross-env": "^1.0.6",
     "css-loader": "^0.23.1",
     "file-loader": "^0.8.4",
-    "vue-loader": "^9.0.0",
+    "vue-loader": "^9.2.2",
     "webpack": "^2.1.0-beta.20",
     "webpack-dev-server": "^2.1.0-beta.0"
   }


### PR DESCRIPTION
The following error occurred.

`[Vue warn]: Failed to mount component: template or render function not defined. (found in anonymous component - use the "name" option for better debugging messages.))
`

I replaced vue-loader 9.0.0 with vue-loader 9.2.2, then the error was resolved.
