### PR TITLE
remove OccurenceOrderPlugin

### DIFF
--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -51,7 +51,6 @@ if (process.env.NODE_ENV === 'production') {
       compress: {
         warnings: false
       }
-    }),
-    new webpack.optimize.OccurenceOrderPlugin()
+    })
   ])
 }


### PR DESCRIPTION
`npm run build` output following error.

```
TypeError: webpack.optimize.OccurenceOrderPlugin is not a function
    at Object.<anonymous> (/Users/shinji/project/webpack-simple-2.0-large/hoge/webpack.config.js:55:5)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at module.exports (/Users/shinji/project/webpack-simple-2.0-large/hoge/node_modules/webpack/bin/convert-argv.js:93:13)
    at Object.<anonymous> (/Users/shinji/project/webpack-simple-2.0-large/hoge/node_modules/webpack/bin/webpack.js:126:40)
    at Module._compile (module.js:413:34)
```

In webpack 2.0, the plugin is no longer needed and occurrence order is on by default.
https://gist.github.com/sokra/27b24881210b56bbaff7#occurrence-order
