### PR TITLE
Fix NODE_ENV when using npm run dev

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,7 @@
   "author": "{{ author }}",
   "private": true,
   "scripts": {
-    "dev": "webpack-dev-server --inline --hot",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --inline --hot",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {


### PR DESCRIPTION
This change forces webpack-dev-server to run in non-production mode so that hot reloading should work correctly in the event that the production environment was set somewhere else. For example, [Atom editor sets the NODE_ENV which can implicitly change the behavior of programs ran from within the editor.](https://github.com/atom/atom/blob/c397bcd46ed03d41532b691f1141cbc7907ccac6/src/initialize-application-window.coffee#L19)